### PR TITLE
Fix: Restore News Pipeline & Resolve Studio 500 Error

### DIFF
--- a/app/Console/Commands/DeepCleanArticles.php
+++ b/app/Console/Commands/DeepCleanArticles.php
@@ -38,7 +38,9 @@ class DeepCleanArticles extends Command
             '%I cannot fulfill%',
             '%As an AI model%',
             '%Gemini API is currently resting%',
-            '%Quota exhausted%'
+            '%Quota exhausted%',
+            '%current summary%',
+            '%editorial brief%'
         ];
 
         $broken = Article::where(function($q) use ($garbage) {

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -191,12 +191,12 @@ class DashboardController extends Controller
         // NEW: Gemini Model Distribution (Pie Chart data)
         $geminiModelDistribution = \Illuminate\Support\Facades\Schema::hasTable('gemini_logs') ?
             \Illuminate\Support\Facades\DB::table('gemini_logs')
-                ->selectRaw('model, SUM(total_tokens) as tokens')
+                ->selectRaw('model_name, SUM(total_tokens) as tokens')
                 ->where('created_at', '>=', now()->subDays(7))
-                ->groupBy('model')
+                ->groupBy('model_name')
                 ->get()
                 ->map(fn($item) => [
-                    'model' => str_replace('models/', '', $item->model),
+                    'model' => str_replace('models/', '', $item->model_name),
                     'tokens' => (int)$item->tokens,
                     'percentage' => $totalGeminiTokens7d > 0 ? round(($item->tokens / $totalGeminiTokens7d) * 100, 1) : 0
                 ]) : collect([]);

--- a/app/Services/GeminiService.php
+++ b/app/Services/GeminiService.php
@@ -17,7 +17,7 @@ class GeminiService
     public function __construct()
     {
         $this->apiKey = config('services.gemini.api_key', env('GEMINI_API_KEY', ''));
-        $this->model = config('services.gemini.model', env('GEMINI_MODEL', 'gemini-2.5-flash'));
+        $this->model = config('services.gemini.model', env('GEMINI_MODEL', 'gemini-1.5-flash'));
     }
 
     /**
@@ -211,8 +211,8 @@ Return ONLY a valid JSON object with these exact keys: \"titular\", \"tldr_twitt
         ];
 
         foreach ($garbagePatterns as $pattern) {
-            if (stripos($content, $pattern) !== false) {
-                throw new \App\Exceptions\GenerationException("Gemini returned garbage/error content ('{$pattern}') for '{$title}'.");
+            if (stripos($content, $pattern) !== false || stripos($content, 'current summary') !== false) {
+                throw new \App\Exceptions\GenerationException("Gemini returned garbage/error content or prompt leak for '{$title}'.");
             }
         }
 


### PR DESCRIPTION
## 📝 Description
This PR resolves two critical issues blocking technical and creative operations on TechyNews.

### 🔴 Problem 1: News Generation Stall & Content 'Shit' Filter
The autonomous news agent was failing to produce valid content because it was referencing an invalid model name (`gemini-2.5-flash`). This caused the API to return error strings or instruction leaks which were inadvertently published, polluting the live feed with 'garbage' content containing internal AI prompts.

### 🔴 Problem 2: Studio Access Error 500
The Studio (Dashboard) was returning a 500 status in production. Logs identified a `SQLSTATE[42S22]` (Column not found) error because the `DashboardController` was querying a `model` column in `gemini_logs`, whereas the database schema correctly defines it as `model_name`.

## 🚀 Solution
1. **Model Correction**: Updated `GeminiService` to use the stable and powerful `gemini-1.5-flash` model.
2. **Instruction Leak Protection**: Implemented stricter output validation in `GeminiService` to detect and block 'instruction leaks' (e.g., phrases like 'current summary') from being published.
3. **Database Column Alignment**: Patched `DashboardController` to use the correct `model_name` column for analytics and model distribution charts.
4. **Editorial Deep Clean**: Enhanced the `articles:deep-clean` command to aggressively target and purge corrupted articles from the database.

## 🧪 Testing Performed
- **Production Log Analysis**: Verified the exact SQL failure via the `/_admin/logs` endpoint.
- **Local Validation**: Confirmed that the `gemini_logs` migration matches the new controller logic.
- **Syntax Check**: Verified the `GeminiService` constructor correctly points to valid model fallbacks.

## 🔗 Issues Context
Closes the generation stall reported by the user and restores editorial dashboard functionality.