### PR TITLE
Feat: Shift content to LatAm focus & Add Generation Debug Route

### DIFF
--- a/app/Services/GeminiService.php
+++ b/app/Services/GeminiService.php
@@ -168,7 +168,7 @@ Return ONLY a JSON array, no markdown fences:
             return "- [{$source}] {$n['title']}";
         }, $newsItems));
 
-        $prompt = "Act as a senior tech analyst and investigative journalist for a site like The Verge or Stratechery.
+        $prompt = "Act as a senior tech analyst and investigative journalist for a premium tech news site with a strong global and Latin American focus (techynews.lat).
 
 ARTICLE TOPIC: {$title}
 EDITORIAL BRIEF: {$ideaPrompt}
@@ -184,6 +184,7 @@ CRITICAL WRITING RULES (ANTI-SLOP & INVESTIGATIVE DEPTH):
 - Headline ('titular'): MUST be extremely punchy, short, and intriguing. ABSOLUTELY MAXIMUM 55 characters. Be a bold curator, not a boring summarizer.
 - Voice: Be direct, slightly opinionated, and highly authoritative. Write as someone who has insider access to the industry.
 - Specificity: Use real data points, architectural details, or market valuation numbers from the context.
+- Latin American Angle: Always include a paragraph connecting the global news to the LATAM market (e.g., impact on remote work, nearshoring, local startup ecosystem, or global disparity). Keep it natural.
 - Prediction: DO NOT summarize. End with a sharp, bold prediction about where this trend goes in the next 12-24 months.
 
 1.  **Thesis**: A single, bold, non-obvious thesis statement. Hook the reader immediately. (HTML: `<p>...</p>`)

--- a/app/Services/NewsService.php
+++ b/app/Services/NewsService.php
@@ -10,12 +10,14 @@ use Illuminate\Support\Facades\Log;
 class NewsService
 {
     /**
-     * RSS sources for trending developer news.
+     * RSS sources for trending developer and tech news (Global + LatAm).
      */
     private array $feeds = [
-        'TechCrunch' => 'https://techcrunch.com/feed/',
-        'The Verge'  => 'https://www.theverge.com/rss/index.xml',
-        'Ars Technica' => 'https://feeds.arstechnica.com/arstechnica/index',
+        'TechCrunch'   => 'https://techcrunch.com/feed/',
+        'Wired'        => 'https://www.wired.com/feed/rss',
+        'Xataka'       => 'https://www.xataka.com/feed.xml',
+        'TechTudo'     => 'https://www.techtudo.com.br/feed',
+        'Contxto'      => 'https://contxto.com/feed/',
     ];
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,18 @@ Route::middleware([])->group(function () {
         return "<pre>Healing complete. " . \Illuminate\Support\Facades\Artisan::output() . "</pre>";
     });
 
+    Route::get('/admin/force-news', function () use ($gate) {
+        $gate();
+        $output = "";
+        try {
+            \Illuminate\Support\Facades\Artisan::call('yolo:agent', ['--limit' => 1]);
+            $output = \Illuminate\Support\Facades\Artisan::output();
+        } catch (\Exception $e) {
+            $output = $e->getMessage();
+        }
+        return "<pre>Manual News Agent Triggered:\n" . htmlspecialchars($output) . "</pre>";
+    });
+
     Route::get('/admin/migrate', function () use ($gate) {
         $gate();
         try {


### PR DESCRIPTION
Closes #18
This PR replaces legacy RSS feeds with LatAm-focused ones (Xataka, Contxto, TechTudo) and updates the Gemini generation prompt to explicitly connect global tech news to the .lat market.

It also adds the `/admin/force-news` route to diagnose why the `yolo:agent` was failing to generate articles in production.